### PR TITLE
Fix: Implement Flexbox sticky footer for improved responsiveness

### DIFF
--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -4,21 +4,6 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-* {
-margin: 0;
-}
-html, body {
-height: 100%;
-}
-.wrapper {
-min-height: 100%;
-height: auto !important;
-height: 100%;
-margin: 0 auto -13em;
-}
-.footer, .push {
-height: 13em;
-}
 a.mail:link{
 	color:#fff;
 }

--- a/index.html
+++ b/index.html
@@ -80,6 +80,16 @@ Mail: web@danielforsberg.se
     }
 
     #open {}
+
+    .wrapper {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .flex-content {
+      flex-grow: 1;
+    }
   </style>
 </head>
 
@@ -115,7 +125,7 @@ Mail: web@danielforsberg.se
       </div>
     </nav>
 
-    <div class="container text-center">
+    <div class="container text-center flex-content">
       <div class="row content">
 
         <div class="col-sm-3 sidenav table-responsive">
@@ -267,7 +277,6 @@ Mail: web@danielforsberg.se
           </script>
         </div>
       </div>
-      <div class="push"></div>
     </div>
 
     <footer class="container-fluid">


### PR DESCRIPTION
Replaced the previous negative-margin based sticky footer with a modern Flexbox solution.

The old method, which utilized a .push div and negative margins on the main wrapper, could sometimes cause the page to be longer than the viewport or fail to keep the footer at the bottom consistently.

The new Flexbox implementation:
- Sets the main wrapper to `display: flex`, `flex-direction: column`, and `min-height: 100vh`.
- Allows the main content area to `flex-grow: 1`, ensuring it takes up available space and pushes the footer to the bottom.
- Removes the need for the .push div and the associated negative margin CSS.

This results in a cleaner, more robust, and more reliable sticky footer behavior across different content lengths and viewport sizes.